### PR TITLE
Add modify search results event

### DIFF
--- a/src/events/SearchResultsEvent.php
+++ b/src/events/SearchResultsEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Smart Map plugin for Craft CMS
+ *
+ * The most comprehensive proximity search and mapping tool for Craft.
+ *
+ * @author    Double Secret Agency
+ * @link      https://www.doublesecretagency.com/
+ * @copyright Copyright (c) 2014 Double Secret Agency
+ */
+
+namespace doublesecretagency\smartmap\events;
+
+use yii\base\Event;
+
+/**
+ * Class SearchResultsEvent
+ * @since 3.2.3
+ */
+class SearchResultsEvent extends Event
+{
+
+    /** @var array The search results. */
+    public $results = [];
+
+}

--- a/src/services/Main.php
+++ b/src/services/Main.php
@@ -15,6 +15,7 @@ use Craft;
 use craft\base\Component;
 use craft\helpers\UrlHelper;
 
+use doublesecretagency\smartmap\events\SearchResultsEvent;
 use doublesecretagency\smartmap\SmartMap;
 
 /**
@@ -23,6 +24,11 @@ use doublesecretagency\smartmap\SmartMap;
  */
 class Main extends Component
 {
+
+    /**
+     * @event SearchResultsEvent The event that is triggered after search results are restructured.
+     */
+    const EVENT_MODIFY_SEARCH_RESULTS = 'modifySearchResults';
 
     // Search for address using Google Maps API
     public function addressSearch($address)
@@ -120,7 +126,14 @@ class Main extends Component
             $restructured['coords'] = $result['geometry']['location'];
             $restructuredResults[] = $restructured;
         }
-        return $restructuredResults;
+
+        // Allow plugins to modify the search results
+        $event = new SearchResultsEvent([
+            'results' => $restructuredResults
+        ]);
+        $this->trigger(self::EVENT_MODIFY_SEARCH_RESULTS, $event);
+
+        return $event->results;
     }
     /*
     for (c in components) {


### PR DESCRIPTION
This brings back the feature to hook into modifying search results. Similar to the `modifySearchResults` hook in v2, but implemented using an event.