### PR TITLE
Add ability to request only non-empty addresses

### DIFF
--- a/src/services/SmartMapService.php
+++ b/src/services/SmartMapService.php
@@ -290,8 +290,8 @@ class SmartMapService extends Component
             $this->_filterSubfield($query, $params);
         }
 
-        // Specify only non-empty lat/lng values
-        if (array_key_exists('notEmpty', $params)) {
+        // Filter by non-null lat/lng values
+        if ($params['hasCoords'] ?? false) {
             $query->subQuery->andWhere(['not', ['or', ['lat' => null], ['lng' => null]]]);
         }
     }

--- a/src/services/SmartMapService.php
+++ b/src/services/SmartMapService.php
@@ -289,6 +289,11 @@ class SmartMapService extends Component
         if (array_key_exists('filter', $params)) {
             $this->_filterSubfield($query, $params);
         }
+
+        // Specify only non-empty lat/lng values
+        if (array_key_exists('notEmpty', $params)) {
+            $query->subQuery->andWhere(['not', ['or', ['lat' => null], ['lng' => null]]]);
+        }
     }
 
     // Filter according to subfield(s)


### PR DESCRIPTION
This pull request adds the ability to request only non-empty addresses. This is important because it is possible that a site has 100 entries but only 2 have addresses, so I want to be able to query just those 2.

You could implement this in various ways so this is just an example implementation:
```php
$elementQuery->mapAddress([
    'notEmpty' => true
]);
```